### PR TITLE
EWB-4038: Default token path for createTokenFetcher

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -8,10 +8,12 @@
 * Support passing in your own authorisation callback to AuthInterceptor.
 
 ##### Enhancements
-* None.
+* `createTokenFetcher` now matches the authentication method (e.g. `OAUTH`) in the auth config JSON in a
+  case-insensitive manner.
 
 ##### Fixes
 * Refresh token is now used in token refresh requests.
+* `createTokenFetcher` now defaults the token path to `\oauth\token` if it is unspecified in the auth config JSON.
 
 ##### Notes
 * None.

--- a/src/main/kotlin/com/zepben/auth/client/ZepbenTokenFetcher.kt
+++ b/src/main/kotlin/com/zepben/auth/client/ZepbenTokenFetcher.kt
@@ -276,7 +276,7 @@ fun createTokenFetcher(
     if (response.statusCode() == StatusCode.OK.code) {
         try {
             val authConfigJson = Json.decodeValue(response.body()) as JsonObject
-            val authMethod = AuthMethod.valueOf(authConfigJson.getString(authTypeField))
+            val authMethod = AuthMethod.valueOf(authConfigJson.getString(authTypeField).uppercase())
             if (authMethod != AuthMethod.NONE) {
                 return ZepbenTokenFetcher(
                     audience = authConfigJson.getString(audienceField),

--- a/src/main/kotlin/com/zepben/auth/client/ZepbenTokenFetcher.kt
+++ b/src/main/kotlin/com/zepben/auth/client/ZepbenTokenFetcher.kt
@@ -67,8 +67,10 @@ class ZepbenTokenFetcher(
     private var tokenExpiry: Instant = Instant.MIN
     private var tokenType: String? = null
 
-    // Likewise add a slash to the tokenPath if one wasn't supplied.
-    private val tokenPath = tokenPath?.takeIf { it.startsWith("/") } ?: tokenPath?.let { "/$it" } ?: "/oauth/token"
+    // Add a leading slash to the tokenPath if it doesn't have one. Default to "/oauth/token" if no tokenPath was given.
+    private val tokenPath =
+        if (tokenPath == null) "/oauth/token"
+        else tokenPath.takeIf { it.startsWith("/") } ?: "/$tokenPath"
 
     // Remove any forward slashes from the end of the issuer to be compatible when joining with the tokenPath
     internal val issuerURL = "${(issuerDomain.takeIf { it.startsWith("https://") } ?: "$issuerProtocol://$issuerDomain").trimEnd('/')}${this.tokenPath}"

--- a/src/main/kotlin/com/zepben/auth/client/ZepbenTokenFetcher.kt
+++ b/src/main/kotlin/com/zepben/auth/client/ZepbenTokenFetcher.kt
@@ -54,7 +54,7 @@ class ZepbenTokenFetcher(
     val issuerDomain: String,
     val authMethod: AuthMethod,
     val issuerProtocol: String = "https",
-    tokenPath: String = "/oauth/token",
+    tokenPath: String? = null,
     val tokenRequestData: JsonObject = JsonObject(),
     val refreshRequestData: JsonObject = JsonObject(),
     private val client: HttpClient = HttpClient.newHttpClient(),
@@ -68,7 +68,7 @@ class ZepbenTokenFetcher(
     private var tokenType: String? = null
 
     // Likewise add a slash to the tokenPath if one wasn't supplied.
-    private val tokenPath = tokenPath.takeIf { it.startsWith("/") } ?: "/$tokenPath"
+    private val tokenPath = tokenPath?.takeIf { it.startsWith("/") } ?: tokenPath?.let { "/$it" } ?: "/oauth/token"
 
     // Remove any forward slashes from the end of the issuer to be compatible when joining with the tokenPath
     internal val issuerURL = "${(issuerDomain.takeIf { it.startsWith("https://") } ?: "$issuerProtocol://$issuerDomain").trimEnd('/')}${this.tokenPath}"
@@ -96,7 +96,7 @@ class ZepbenTokenFetcher(
         verifyCertificate: Boolean,
         issuerProtocol: String = "https",
         requestContentType: String = "application/json",
-        tokenPath: String = "/oauth/token",
+        tokenPath: String? = null,
         tokenRequestData: JsonObject = JsonObject(),
         refreshRequestData: JsonObject = JsonObject(),
         createBody: (JsonObject) -> String = { it.toString() }
@@ -136,7 +136,7 @@ class ZepbenTokenFetcher(
         caFilename: String?,
         issuerProtocol: String = "https",
         requestContentType: String = "application/json",
-        tokenPath: String = "/oauth/token",
+        tokenPath: String? = null,
         tokenRequestData: JsonObject = JsonObject(),
         refreshRequestData: JsonObject = JsonObject(),
         createBody: (JsonObject) -> String = { it.toString() }

--- a/src/test/kotlin/com/zepben/auth/client/ZepbenTokenFetcherTest.kt
+++ b/src/test/kotlin/com/zepben/auth/client/ZepbenTokenFetcherTest.kt
@@ -94,6 +94,19 @@ internal class ZepbenTokenFetcherTest {
     }
 
     @Test
+    fun testCreateTokenFetcherNoTokenPath() {
+        doReturn(StatusCode.OK.code).`when`(response).statusCode()
+        doReturn(
+            "{\"authType\": \"OAUTH\", \"audience\": \"test_audience\", \"issuerDomain\": \"test_issuer\"}"
+        ).`when`(response).body()
+
+        val tokenFetcher = createTokenFetcher("https://testaddress", confClient = client, authClient = client)
+        verify(client).send(any(), any<HttpResponse.BodyHandler<String>>())
+        assertThat(tokenFetcher?.audience, equalTo("test_audience"))
+        assertThat(tokenFetcher?.issuerDomain, equalTo("test_issuer"))
+    }
+
+    @Test
     fun testCreateTokenFetcherNoAuth() {
         doReturn(StatusCode.OK.code).`when`(response).statusCode()
         doReturn(

--- a/src/test/kotlin/com/zepben/auth/client/ZepbenTokenFetcherTest.kt
+++ b/src/test/kotlin/com/zepben/auth/client/ZepbenTokenFetcherTest.kt
@@ -107,6 +107,18 @@ internal class ZepbenTokenFetcherTest {
     }
 
     @Test
+    fun testCreateTokenFetcherLowercaseAuthType() {
+        doReturn(StatusCode.OK.code).`when`(response).statusCode()
+        doReturn(
+            "{\"authType\": \"oauth\", \"audience\": \"test_audience\", \"issuerDomain\": \"test_issuer\", \"tokenPath\": \"/oauth/token\"}"
+        ).`when`(response).body()
+
+        val tokenFetcher = createTokenFetcher("https://testaddress", confClient = client, authClient = client)
+        verify(client).send(any(), any<HttpResponse.BodyHandler<String>>())
+        assertThat(tokenFetcher?.authMethod, equalTo(AuthMethod.OAUTH))
+    }
+
+    @Test
     fun testCreateTokenFetcherNoAuth() {
         doReturn(StatusCode.OK.code).`when`(response).statusCode()
         doReturn(


### PR DESCRIPTION
# Description

`createTokenFetcher` currently throws an error if the `tokenPath` field is not found in the auth config JSON. It should instead default to `/oauth/token`, which this change fixes. This also matches the authentication method (e.g. `OAUTH`) in a case-insensitive way.

# Associated tasks:

Tasks blocking this one:
- None

Tasks this is blocking:
- Noose baseline functionality (PR TBA)

# Checklist:

These are always required, if you do not do them, reviewers will be angry:
- [x] I have performed a self review of my own code.
- [x] I have added/updated unit tests for these changes, and if not I have explained why they are not necessary.

These you can remove from the list if they are not applicable for this PR.
- [x] I have updated the changelog.
- [x] I have commented my code in any hard-to-understand or hacky areas.
- [x] I have handled all new warnings generated by the compiler or IDE.
- [x] I have considered if this is a breaking change and have communicated it with other team members if so. (Not breaking)
