### PR TITLE
[DEV-571] Pass down missing configuration to the authorization call site

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -10,7 +10,8 @@
 * None.
 
 ### Fixes
-* None.
+* Evolve-conn allowed the customization of the claim where permissions should be retrieved from. 
+  This functionality only worked for gRPC requests. It has now been patched to work for HTTP requests as well
 
 ### Notes
 * None.

--- a/src/main/kotlin/com/zepben/auth/server/Auth0AuthHandler.kt
+++ b/src/main/kotlin/com/zepben/auth/server/Auth0AuthHandler.kt
@@ -26,7 +26,8 @@ import io.vertx.ext.web.handler.HttpException
 class Auth0AuthHandler(
     private val authProvider: JWTAuthProvider,
     requiredClaims: Set<String>,
-    private val skip: String? = null
+    private val skip: String? = null,
+    private val permissionsField: String
 ) :
     AuthenticationHandler {
 
@@ -53,7 +54,7 @@ class Auth0AuthHandler(
         }
         for (authority in authorities) {
             val token = user.attributes().getValue("token") as DecodedJWT
-            val resp = JWTAuthoriser.authorise(token, authority)
+            val resp = JWTAuthoriser.authorise(token, authority, permissionsField)
             if (resp.statusCode !== StatusCode.OK) {
                 handler.handle(Future.failedFuture(HttpException(403, "Could not authorise all requested permissions. This is likely a bug.")))
                 return

--- a/src/main/kotlin/com/zepben/auth/server/AuthRoute.kt
+++ b/src/main/kotlin/com/zepben/auth/server/AuthRoute.kt
@@ -39,8 +39,9 @@ class AuthRoute {
             audience: String,
             jwkProvider: UrlJwkProvider,
             issuer: String,
+            permissionsField: String,
             requiredClaims: Iterable<String> = emptySet(),
-            isRegexPath: Boolean = false
+            isRegexPath: Boolean = false,
         ): (AvailableRoute) -> Route =
             { availableRoute ->
                 when (availableRoute) {
@@ -52,7 +53,8 @@ class AuthRoute {
                             .addHandler(
                                 Auth0AuthHandler(
                                     JWTAuthProvider(JWTAuthenticator(audience, issuer, jwkProvider)),
-                                    mutableSetOf<String>().apply { addAll(requiredClaims) }
+                                    mutableSetOf<String>().apply { addAll(requiredClaims) },
+                                    permissionsField = permissionsField
                                 )
                             )
                             .build()


### PR DESCRIPTION
# Description

The `permissionsField` property override was available for gRPC requests but not for HTTP REST requests. This PR adds the configuration option and passes it down to the appropriate call site so that upstream consumers are able to set an override if required. This is required for EntraID support in EWB as its permissions are specified in the claim `roles`.

# Associated tasks

List any other tasks / PRs that are required to be merged alongside this one (e.g. front end task for back end change or vice versa). If a PR exists, add a link. If not, just add an appropriate note here so reviewers know there is a dependency and will hold off merging until all things are ready.

# Checklist

If any of these are not applicable, strikethrough the line `~like this~`. **Do not delete it!**. Let the reviewer decide if you should have done it.

### Code
- [x] I have performed a self review of my own code (including checking issues raised when creating the PR).
- [x] I have added/updated unit tests for these changes, and if not I have explained why they are not necessary.
- [x] I have commented my code in any hard-to-understand or hacky areas.
- [x] I have handled all new warnings generated by the compiler or IDE.
- [x] I have rebased onto the target branch (usually main).
      
### Documentation
- [x] I have updated the changelog.
- [x] I have updated any documentation required for these changes.

# Breaking Changes
- [x] I have considered if this is a breaking change and will communicate it with other team members if so.
