### PR TITLE
[DEV-2604] Handle JwkExceptions cleanly

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -10,7 +10,9 @@
 * None.
 
 ### Fixes
-* None.
+* JWTAuthenticator will now handle JwkExceptions and return 403 Unauthenticated responses.
+* JWTAuthenticator will now pass through unhandled exceptions to the caller rather than wrapping them in 500 errors.
+  Exceptions now need to be handled by the caller of `authenticate()`.
 
 ### Notes
 * None.

--- a/src/main/kotlin/com/zepben/auth/server/JWKHolder.kt
+++ b/src/main/kotlin/com/zepben/auth/server/JWKHolder.kt
@@ -27,7 +27,7 @@ class JWKHolder(
     fun getKeyFromJwk(kid: String, issuer: TrustedIssuer): Jwk =
         keys[issuer.issuerDomain]?.get(kid)?: run {
             keys[issuer.issuerDomain] = jwkProvider(issuer)
-            keys[issuer.issuerDomain]?.get(kid) ?: throw JwkException("Unable to find key $kid in jwk endpoint. Check your JWK URL.")
+            keys[issuer.issuerDomain]?.get(kid) ?: throw SigningKeyNotFoundException("Unable to find key $kid in jwk endpoint. Check your JWK URL.", null)
         }
 }
 

--- a/src/main/kotlin/com/zepben/auth/server/JWTAuthenticator.kt
+++ b/src/main/kotlin/com/zepben/auth/server/JWTAuthenticator.kt
@@ -8,12 +8,14 @@
 
 package com.zepben.auth.server
 
+import com.auth0.jwk.JwkException
 import com.auth0.jwt.JWT
 import com.auth0.jwt.exceptions.*
 import com.auth0.jwt.interfaces.DecodedJWT
 import com.zepben.auth.common.AuthException
 import com.zepben.auth.common.StatusCode
 import io.vertx.ext.web.handler.HttpException
+import org.slf4j.LoggerFactory
 
 const val CONTENT_TYPE = "Content-Type"
 
@@ -49,6 +51,8 @@ open class JWTAuthenticator(
     )
 ) : TokenAuthenticator {
 
+    private val logger = LoggerFactory.getLogger(javaClass)
+
     override fun authenticate(token: String?): AuthResponse =
         if (token.isNullOrEmpty()) {
             AuthResponse(StatusCode.UNAUTHENTICATED, "No token was provided")
@@ -71,8 +75,8 @@ open class JWTAuthenticator(
                 AuthResponse(StatusCode.PERMISSION_DENIED, claim.message, claim)
             } catch (i: IllegalArgumentException) {
                 AuthResponse(StatusCode.MALFORMED_TOKEN, i.message, i)
-            } catch (e: Exception) {
-                AuthResponse(StatusCode.UNKNOWN, e.message, e)
+            } catch (j: JwkException) {
+               AuthResponse(StatusCode.UNAUTHENTICATED, j.message, j)
             }
         }
 }

--- a/src/main/kotlin/com/zepben/auth/server/grpc/AuthInterceptor.kt
+++ b/src/main/kotlin/com/zepben/auth/server/grpc/AuthInterceptor.kt
@@ -84,6 +84,8 @@ class AuthInterceptor(
             val ctx: Context = Context.current()
             return Contexts.interceptCall(ctx, serverCall, metadata, serverCallHandler)
         }
+        // XXXX: Maybe in the future we should have a callback to a logger here to log failed requests? Currently the client is the only one
+        //       that will see the any error messages upon connection.
         serverCall.close(authResp.status, Metadata())
         return object : ServerCall.Listener<ReqT>() {} // no-op
     }

--- a/src/main/kotlin/com/zepben/auth/server/grpc/AuthInterceptor.kt
+++ b/src/main/kotlin/com/zepben/auth/server/grpc/AuthInterceptor.kt
@@ -85,7 +85,7 @@ class AuthInterceptor(
             return Contexts.interceptCall(ctx, serverCall, metadata, serverCallHandler)
         }
         // XXXX: Maybe in the future we should have a callback to a logger here to log failed requests? Currently the client is the only one
-        //       that will see the any error messages upon connection.
+        //       that will see any error messages upon connection, and thus we rely on clients for reporting issues.
         serverCall.close(authResp.status, Metadata())
         return object : ServerCall.Listener<ReqT>() {} // no-op
     }

--- a/src/test/kotlin/com/zepben/auth/server/JWKHolderTest.kt
+++ b/src/test/kotlin/com/zepben/auth/server/JWKHolderTest.kt
@@ -10,6 +10,7 @@ package com.zepben.auth.server
 
 import com.auth0.jwk.Jwk
 import com.auth0.jwk.JwkException
+import com.auth0.jwk.SigningKeyNotFoundException
 import com.zepben.auth.client.ProviderDetails
 import com.zepben.testutils.exception.ExpectException
 import io.mockk.every
@@ -98,7 +99,7 @@ class JWKHolderTest {
     fun `JWKHolder throws on unable to find after refreshing cache`() {
         ExpectException.expect {
             holderUnderTest.getKeyFromJwk("keyId_34", trustedIssuerOne)
-        }.toThrow<JwkException>().withMessage("Unable to find key keyId_34 in jwk endpoint. Check your JWK URL.")
+        }.toThrow<SigningKeyNotFoundException>().withMessage("Unable to find key keyId_34 in jwk endpoint. Check your JWK URL.")
 
         validateKeyRequest(trustedIssuerOne, jwkProvider, true)
     }


### PR DESCRIPTION
Handles JwkExceptions being thrown when fetching tokens/jwks.

This occurred when M$ revoked a JWK and caused a SigningKeyNotFound exception. We were previously returning them as 500's, but that's bad. They'll now be handled as 403's.

# Test Steps

Tests hopefully cover it, but need to run EWB with this change and smoke test everything. I will do this as part of the poles -> PSR change

# Checklist

If any of these are not applicable, strikethrough the line `~like this~`. **Do not delete it!**. Let the reviewer decide if you should have done it.

### Code
- [x] I have performed a self review of my own code (including checking issues raised when creating the PR).
- [x] I have added/updated unit tests for these changes, and if not I have explained why they are not necessary.
- [x] I have commented my code in any hard-to-understand or hacky areas.
- [x] I have handled all new warnings generated by the compiler or IDE.
- [x] I have rebased onto the target branch (usually main).

### Documentation
- [x] I have updated the changelog.
- [x] I have updated any documentation required for these changes.

# Breaking Changes
- [x] I have considered if this is a breaking change and will communicate it with other team members by posting it on the Slack **breaking-changes** channel.

Not breaking, just a bug fix
